### PR TITLE
X-C LAMMPS: Adding popen and pclose to the libc imports file

### DIFF
--- a/sysroot_extras/libc.imports
+++ b/sysroot_extras/libc.imports
@@ -36,6 +36,9 @@ dlsym
 dlclose
 dlerror
 
+# Process I/O
+popen
+
 # Environment
 uname
 getpid

--- a/sysroot_extras/libc.imports
+++ b/sysroot_extras/libc.imports
@@ -38,6 +38,7 @@ dlerror
 
 # Process I/O
 popen
+pclose
 
 # Environment
 uname


### PR DESCRIPTION
Related to faasm/faasm-experiments#13