### PR TITLE
Including native install of emulator and libraries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   formatting:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+build-wasm/
+build-native/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,5 @@ add_subdirectory(third-party/faabric)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/third-party/faabric/src)
 
 add_subdirectory(libfaasm)
-add_subdirectory(libfaasmpi)
 add_subdirectory(emulator)
 add_subdirectory(tests)

--- a/docker/cpp-sysroot.dockerfile
+++ b/docker/cpp-sysroot.dockerfile
@@ -38,6 +38,7 @@ RUN inv eigen --native
 
 RUN inv dev.cmake
 RUN inv dev.cc emulator
+RUN inv dev.install emulator
 
 # -----------------------------
 # LIBRARIES (WASM AND NATIVE)

--- a/docker/cpp-sysroot.dockerfile
+++ b/docker/cpp-sysroot.dockerfile
@@ -11,6 +11,7 @@ RUN apt install -y \
     autotools-dev \
     libtool \
     python3-dev \
+    python3-venv \
     python3-pip
 
 # Get the code

--- a/docker/cpp-sysroot.dockerfile
+++ b/docker/cpp-sysroot.dockerfile
@@ -40,7 +40,7 @@ RUN inv dev.cmake
 RUN inv dev.cc emulator
 
 # -----------------------------
-# WASM LIBRARIES
+# LIBRARIES (WASM AND NATIVE)
 # -----------------------------
 
 # Install files
@@ -59,11 +59,14 @@ RUN inv libffi
 RUN inv clapack
 RUN inv clapack --clean --shared
 
-# Install Faasm CPP wasm lib
+# Install Faasm CPP lib
 RUN inv libfaasm
+RUN inv libfaasm --native
 
-# Install Faabric OpenMP wasm lib
-RUN inv libfaasmp --clean
+# Install Faasm OpenMP lib
+RUN inv libfaasmp
+RUN inv libfaasmp --native
 
 # Install Faabric MPI lib
-RUN inv libfaasmpi --clean
+RUN inv libfaasmpi
+RUN inv libfaasmpi --native

--- a/faasmtools/build.py
+++ b/faasmtools/build.py
@@ -4,6 +4,7 @@ from subprocess import run
 
 # Directories
 FAASM_LOCAL_DIR = "/usr/local/faasm"
+FAASM_NATIVE_DIR = join(FAASM_LOCAL_DIR, "native")
 WASM_SYSROOT = join(FAASM_LOCAL_DIR, "llvm-sysroot")
 WASM_LIB_INSTALL = "{}/lib/wasm32-wasi".format(WASM_SYSROOT)
 WASM_TOOLCHAIN_ROOT = "/usr/local/faasm/toolchain"

--- a/libfaasmp/CMakeLists.txt
+++ b/libfaasmp/CMakeLists.txt
@@ -43,7 +43,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Wasm")
 else ()
     message(STATUS "Libfaasmp native build")
  
-    add_library(faasmp SHARED ${LIB_FILES})
+    add_library(faasmp STATIC ${LIB_FILES})
     set_target_properties(faasmp PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 
     install(TARGETS faasmp

--- a/libfaasmpi/CMakeLists.txt
+++ b/libfaasmpi/CMakeLists.txt
@@ -16,50 +16,56 @@ set(LIB_FILES
     faasmpi.cpp
 )
 
-# Only do the install if we're doing a WASM build
-# WARNING - this overwrites the existing mpi.h on the system if not used in a
-# wasm build
+add_library(faasmpi STATIC ${LIB_FILES})
+set_target_properties(faasmpi PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
+
+# Install Faabric MPI library
+set(FAABRIC_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../third-party/faabric/src/mpi)
+set(FAABRIC_BINARY_DIR ${FAABRIC_SOURCE_DIR}/build)
+
+add_subdirectory(${FAABRIC_SOURCE_DIR} ${FAABRIC_BINARY_DIR})
+add_dependencies(faasmpi faabricmpi)
+install(FILES ${FAABRIC_BINARY_DIR}/libfaabricmpi.a
+        DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
+)
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Wasm")
     message(STATUS "Libfaasmpi WebAssembly build")
 
-    add_library(faasmpi STATIC ${LIB_FILES})
-    set_target_properties(faasmpi PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
-
-    # Add Faabric dependency
-    set(FAABRIC_SOURCE_DIR ${CMAKE_BINARY_DIR}/../../third-party/faabric/src/mpi)
-    set(FAABRIC_BINARY_DIR ${FAABRIC_SOURCE_DIR}/build)
-    add_subdirectory(${FAABRIC_SOURCE_DIR} ${FAABRIC_BINARY_DIR})
-    add_dependencies(faasmpi faabricmpi)
-    install(FILES ${FAABRIC_BINARY_DIR}/libfaabricmpi.a
-            DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
-    )
-
-    # Install in sysroot
     install(TARGETS faasmpi
             ARCHIVE DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
             LIBRARY DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
             PUBLIC_HEADER DESTINATION ${CMAKE_SYSROOT}/include/faasmpi
     )
 
-    # Add imports
+    # Add imports file
     install(FILES faasmpi.imports
             DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
             RENAME libfaasmpi.imports
     )
 
-    # Symlink header
-    install(CODE "execute_process( \
-        COMMAND ${CMAKE_COMMAND} -E create_symlink \
-        ${CMAKE_SYSROOT}/include/faabric/mpi/mpi.h \
-        ${CMAKE_SYSROOT}/include/mpi.h   \
-        )"
-    )
-
-    # Symlink library
+    # Symlink library as libmpi
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
         ${CMAKE_SYSROOT}/lib/wasm32-wasi/libfaabricmpi.a \
         ${CMAKE_SYSROOT}/lib/wasm32-wasi/libmpi.a   \
         )"
     )
+else()
+    message(STATUS "Libfaasmpi native build")
+
+    install(TARGETS faasmpi
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+            PUBLIC_HEADER DESTINATION include/faasmpi
+            )
 endif()
+
+# Symlink header (common to wasm and native builds)
+# WARNING - this may overwrite the existing mpi.h on the system 
+install(CODE "execute_process( \
+    COMMAND ${CMAKE_COMMAND} -E create_symlink \
+    ${CMAKE_INSTALL_PREFIX}/include/faabric/mpi/mpi.h \
+    ${CMAKE_INSTALL_PREFIX}/include/mpi.h   \
+    )"
+)

--- a/libfaasmpi/CMakeLists.txt
+++ b/libfaasmpi/CMakeLists.txt
@@ -25,12 +25,13 @@ set(FAABRIC_BINARY_DIR ${FAABRIC_SOURCE_DIR}/build)
 
 add_subdirectory(${FAABRIC_SOURCE_DIR} ${FAABRIC_BINARY_DIR})
 add_dependencies(faasmpi faabricmpi)
-install(FILES ${FAABRIC_BINARY_DIR}/libfaabricmpi.a
-        DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
-)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Wasm")
     message(STATUS "Libfaasmpi WebAssembly build")
+
+    install(FILES ${FAABRIC_BINARY_DIR}/libfaabricmpi.a
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/wasm32-wasi
+    )
 
     install(TARGETS faasmpi
             ARCHIVE DESTINATION ${CMAKE_SYSROOT}/lib/wasm32-wasi
@@ -48,7 +49,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Wasm")
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
         ${CMAKE_SYSROOT}/lib/wasm32-wasi/libfaabricmpi.a \
-        ${CMAKE_SYSROOT}/lib/wasm32-wasi/libmpi.a   \
+        ${CMAKE_SYSROOT}/lib/wasm32-wasi/libmpi.a \
         )"
     )
 else()
@@ -62,7 +63,8 @@ else()
 endif()
 
 # Symlink header (common to wasm and native builds)
-# WARNING - this may overwrite the existing mpi.h on the system 
+# WARNING - if you use the default CMAKE_INSTALL_PREFIX, this may overwrite the 
+# existing mpi.h on the system 
 install(CODE "execute_process( \
     COMMAND ${CMAKE_COMMAND} -E create_symlink \
     ${CMAKE_INSTALL_PREFIX}/include/faabric/mpi/mpi.h \

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -54,3 +54,16 @@ def cc(ctx, target, clean=False):
         shell=True,
         check=True,
     )
+
+
+@task
+def install(ctx, target):
+    """
+    Installs the given target
+    """
+    run(
+        "ninja install {}".format(target),
+        cwd=BUILD_DIR,
+        shell=True,
+        check=True,
+    )

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -6,6 +6,7 @@ from shutil import rmtree
 from invoke import task
 
 from faasmtools.env import PROJ_ROOT
+from faasmtools.build import FAASM_NATIVE_DIR
 
 BUILD_DIR = "/build/faasm-toolchain"
 
@@ -27,6 +28,7 @@ def cmake(ctx, clean=False, build="Debug"):
         "-DCMAKE_BUILD_TYPE={}".format(build),
         "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-10",
         "-DCMAKE_C_COMPILER=/usr/bin/clang-10",
+        "-DCMAKE_INSTALL_PREFIX={}".format(FAASM_NATIVE_DIR),
         PROJ_ROOT,
     ]
 

--- a/tasks/lib.py
+++ b/tasks/lib.py
@@ -26,14 +26,12 @@ def build_faasm_lib(subdir, clean=False, native=False):
             "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-10",
         ]
     else:
-        extras = ["-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE)]
+        extras = [
+            "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
+            "-DCMAKE_INSTALL_PREFIX={}".format(WASM_SYSROOT),
+        ]
 
-    build_cmd = [
-        "cmake",
-        "-GNinja",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX={}".format(WASM_SYSROOT),
-    ]
+    build_cmd = ["cmake", "-GNinja", "-DCMAKE_BUILD_TYPE=Release"]
 
     build_cmd.extend(extras)
     build_cmd.append(work_dir)

--- a/tasks/lib.py
+++ b/tasks/lib.py
@@ -3,7 +3,7 @@ from os import makedirs
 from subprocess import run
 from shutil import rmtree
 
-from faasmtools.build import CMAKE_TOOLCHAIN_FILE
+from faasmtools.build import CMAKE_TOOLCHAIN_FILE, WASM_SYSROOT
 
 from faasmtools.env import PROJ_ROOT
 
@@ -32,6 +32,7 @@ def build_faasm_lib(subdir, clean=False, native=False):
         "cmake",
         "-GNinja",
         "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX={}".format(WASM_SYSROOT),
     ]
 
     build_cmd.extend(extras)

--- a/tasks/lib.py
+++ b/tasks/lib.py
@@ -1,0 +1,46 @@
+from os.path import join, exists
+from os import makedirs
+from subprocess import run
+from shutil import rmtree
+
+from faasmtools.build import CMAKE_TOOLCHAIN_FILE
+
+from faasmtools.env import PROJ_ROOT
+
+
+def build_faasm_lib(subdir, clean=False, native=False):
+    """
+    Builds one of the libraries included in this repo
+    """
+    work_dir = join(PROJ_ROOT, subdir)
+    build_dir = join(work_dir, "build-native" if native else "build-wasm")
+
+    if exists(build_dir) and clean:
+        rmtree(build_dir)
+
+    makedirs(build_dir, exist_ok=True)
+
+    if native:
+        extras = [
+            "-DCMAKE_C_COMPILER=/usr/bin/clang-10",
+            "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-10",
+        ]
+    else:
+        extras = ["-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE)]
+
+    build_cmd = [
+        "cmake",
+        "-GNinja",
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+
+    build_cmd.extend(extras)
+    build_cmd.append(work_dir)
+
+    build_cmd_str = " ".join(build_cmd)
+    print(build_cmd_str)
+
+    run(build_cmd_str, shell=True, cwd=build_dir, check=True)
+
+    run("ninja", shell=True, cwd=build_dir, check=True)
+    run("ninja install", shell=True, cwd=build_dir, check=True)

--- a/tasks/lib.py
+++ b/tasks/lib.py
@@ -3,7 +3,11 @@ from os import makedirs
 from subprocess import run
 from shutil import rmtree
 
-from faasmtools.build import CMAKE_TOOLCHAIN_FILE, WASM_SYSROOT
+from faasmtools.build import (
+    CMAKE_TOOLCHAIN_FILE,
+    WASM_SYSROOT,
+    FAASM_NATIVE_DIR,
+)
 
 from faasmtools.env import PROJ_ROOT
 
@@ -14,6 +18,7 @@ def build_faasm_lib(subdir, clean=False, native=False):
     """
     work_dir = join(PROJ_ROOT, subdir)
     build_dir = join(work_dir, "build-native" if native else "build-wasm")
+    install_dir = FAASM_NATIVE_DIR if native else WASM_SYSROOT
 
     if exists(build_dir) and clean:
         rmtree(build_dir)
@@ -28,10 +33,14 @@ def build_faasm_lib(subdir, clean=False, native=False):
     else:
         extras = [
             "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
-            "-DCMAKE_INSTALL_PREFIX={}".format(WASM_SYSROOT),
         ]
 
-    build_cmd = ["cmake", "-GNinja", "-DCMAKE_BUILD_TYPE=Release"]
+    build_cmd = [
+        "cmake",
+        "-GNinja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
+    ]
 
     build_cmd.extend(extras)
     build_cmd.append(work_dir)

--- a/tasks/libfaasm.py
+++ b/tasks/libfaasm.py
@@ -1,38 +1,10 @@
-from os.path import join, exists
-from os import makedirs
-from subprocess import run
-from shutil import rmtree
-
-from faasmtools.build import CMAKE_TOOLCHAIN_FILE
 from invoke import task
-
-from faasmtools.env import PROJ_ROOT
+from tasks.lib import build_faasm_lib
 
 
 @task(default=True)
-def build(ctx, clean=False):
+def build(ctx, clean=False, native=False):
     """
     Builds faasm C/C++ lib
     """
-    work_dir = join(PROJ_ROOT, "libfaasm")
-    build_dir = join(work_dir, "build")
-
-    if exists(build_dir):
-        rmtree(build_dir)
-    makedirs(build_dir)
-
-    build_cmd = [
-        "cmake",
-        "-GNinja",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
-        work_dir,
-    ]
-
-    build_cmd_str = " ".join(build_cmd)
-    print(build_cmd_str)
-
-    run(build_cmd_str, shell=True, cwd=build_dir, check=True)
-
-    run("ninja", shell=True, cwd=build_dir, check=True)
-    run("ninja install", shell=True, cwd=build_dir, check=True)
+    build_faasm_lib("libfaasm", clean=clean, native=native)

--- a/tasks/libfaasmp.py
+++ b/tasks/libfaasmp.py
@@ -1,41 +1,10 @@
-from os.path import join, exists
-from os import makedirs
-from subprocess import run
-from shutil import rmtree
-
-from faasmtools.build import CMAKE_TOOLCHAIN_FILE
 from invoke import task
-
-from faasmtools.env import PROJ_ROOT
+from tasks.lib import build_faasm_lib
 
 
 @task(default=True)
-def build(ctx, clean=False):
+def build(ctx, clean=False, native=False):
     """
-    Builds Faabric OpenMP C/C++ lib
+    Builds Faasm OpenMP library
     """
-    work_dir = join(PROJ_ROOT, "libfaasmp")
-    build_dir = join(work_dir, "build")
-
-    if exists(build_dir):
-        if clean:
-            rmtree(build_dir)
-            makedirs(build_dir)
-    else:
-        makedirs(build_dir)
-
-    build_cmd = [
-        "cmake",
-        "-GNinja",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
-        work_dir,
-    ]
-
-    build_cmd_str = " ".join(build_cmd)
-    print(build_cmd_str)
-
-    run(build_cmd_str, shell=True, cwd=build_dir, check=True)
-
-    run("ninja", shell=True, cwd=build_dir, check=True)
-    run("ninja install", shell=True, cwd=build_dir, check=True)
+    build_faasm_lib("libfaasmp", clean=clean, native=native)

--- a/tasks/libfaasmpi.py
+++ b/tasks/libfaasmpi.py
@@ -1,41 +1,10 @@
-from os.path import join, exists
-from os import makedirs
-from subprocess import run
-from shutil import rmtree
-
-from faasmtools.build import CMAKE_TOOLCHAIN_FILE
 from invoke import task
-
-from faasmtools.env import PROJ_ROOT
+from tasks.lib import build_faasm_lib
 
 
 @task(default=True)
-def build(ctx, clean=False):
+def build(ctx, clean=False, native=False):
     """
-    Builds Faabric MPI C/C++ lib
+    Builds Faabric MPI lib
     """
-    work_dir = join(PROJ_ROOT, "libfaasmpi")
-    build_dir = join(work_dir, "build")
-
-    if exists(build_dir):
-        if clean:
-            rmtree(build_dir)
-            makedirs(build_dir)
-    else:
-        makedirs(build_dir)
-
-    build_cmd = [
-        "cmake",
-        "-GNinja",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
-        work_dir,
-    ]
-
-    build_cmd_str = " ".join(build_cmd)
-    print(build_cmd_str)
-
-    run(build_cmd_str, shell=True, cwd=build_dir, check=True)
-
-    run("ninja", shell=True, cwd=build_dir, check=True)
-    run("ninja install", shell=True, cwd=build_dir, check=True)
+    build_faasm_lib("libfaasmpi", clean=clean, native=native)


### PR DESCRIPTION
This is necessary for building Faasm functions natively. 

At the very least this is required for `clang-tidy` to work on files that will be built for Faasm (as this will run on the natively built code using the system headers rather than those in the wasm sysroot). More generally it allows people to build and use the emulator with their native code, even if it has things like `#import <faasm/faasm.h>`.